### PR TITLE
New transferVariable()

### DIFF
--- a/src/main/resources/Datavyu_API.rb
+++ b/src/main/resources/Datavyu_API.rb
@@ -1770,6 +1770,9 @@ def transferVariable(db1, db2, remove, *varnames)
         cell.arglist.each{ |x|
           c.change_arg(x,cell.get_arg(x))
         }
+        c.ordinal = cell.ordinal
+        c.onset = cell.onset
+        c.offset = cell.offset
       end
       setVariable(key.to_s,newvar)
       print_debug("Wrote column : #{key.to_s} with #{newvar.cells.length} cells")


### PR DESCRIPTION
Changed the transferVariable() method to recreate the columns in the new database from scratch by copying over arguments cell by cell.
