### PR TITLE
Modifies the "arguments" section of the JSON file format to be a uniquely keyed object

### DIFF
--- a/src/main/java/org/datavyu/controllers/ExportDatabaseFileController.java
+++ b/src/main/java/org/datavyu/controllers/ExportDatabaseFileController.java
@@ -417,7 +417,7 @@ public final class ExportDatabaseFileController {
 
                 column.getRootNode().childArguments.forEach(argument -> {
                     try {
-                        g.writeStringField(argument.type.name(), argument.name);
+                        g.writeStringField(argument.name, argument.type.name());
                     } catch (IOException e) {
                         e.printStackTrace();
                     }

--- a/src/main/java/org/datavyu/controllers/OpenDataStoreFileController.java
+++ b/src/main/java/org/datavyu/controllers/OpenDataStoreFileController.java
@@ -219,8 +219,7 @@ public final class OpenDataStoreFileController {
                                                 while (!JsonToken.END_OBJECT.equals(token)) {
                                                     token = parser.nextToken();
                                                     if (token == null) { break; }
-                                                    if (JsonToken.START_OBJECT.equals(token) || JsonToken
-                                                            .START_OBJECT.equals(token) || JsonToken.END_OBJECT
+                                                    if (JsonToken.START_OBJECT.equals(token) || JsonToken.END_OBJECT
                                                             .equals(token)) {
                                                         break;
                                                     }
@@ -233,10 +232,10 @@ public final class OpenDataStoreFileController {
                                                         variableArg.name = parser.getValueAsString();
                                                     }
                                                     if (variableType == Argument.Type.MATRIX) {
-                                                        if (getVarType(parser.getCurrentName()) != null) {
+                                                        if (getVarType(parser.getValueAsString()) != null) {
                                                             variableArg.childArguments.add(new Argument(parser
-                                                                    .getValueAsString(), getVarType(parser
-                                                                    .getCurrentName())));
+                                                                    .getCurrentName(), getVarType(parser
+                                                                    .getValueAsString())));
                                                         } else {
                                                             logger.warn("Unknown argument ('" + parser.getCurrentName
                                                                     () + "' line " + parser.getCurrentLocation()

--- a/src/main/java/org/datavyu/views/DatavyuView.java
+++ b/src/main/java/org/datavyu/views/DatavyuView.java
@@ -2603,12 +2603,12 @@ public final class DatavyuView extends FrameView implements FileDropEventListene
         if (totalNumberOfVisibleColumns == 0) {
             newCellMenuItem.setEnabled(false);
             exportJSON.setEnabled(false);
-            importJSON.setEnabled(false);
         } else {
             newCellMenuItem.setEnabled(true);
             exportJSON.setEnabled(true);
-            importJSON.setEnabled(true);
         }
+
+        importJSON.setEnabled(true);
 
         List<Variable> selectedCols = Datavyu.getProjectController().getDataStore().getSelectedVariables();
 


### PR DESCRIPTION
Modifies the "arguments" section of the JSON file format from 'argtype' : 'argname' to 'argname' : 'argtype' so that the keys are unique. This allows behavior
to be consistent across different JSON importers (as this is a problem when converting a JSON file to a Python or Ruby dictionary, for example) and is consistent with
the recommendation in JSON RFC 8259.

Additionally, "Import Passes From JSON" should be enabled when there are
no columns in the spreadsheet. This has also been fixed.

This currently breaks functionality with already exported JSON files, though I'd be happy to patch that if anyone has been using this feature.