### PR TITLE
Avoid a NPE by caching the parent column for a cell

### DIFF
--- a/src/main/java/org/datavyu/views/discrete/ColumnDataPanel.java
+++ b/src/main/java/org/datavyu/views/discrete/ColumnDataPanel.java
@@ -72,12 +72,12 @@ public final class ColumnDataPanel extends JPanel implements KeyEventDispatcher 
     /**
      * Creates a new ColumnDataPanel.
      *
-     * @param db       The datastore that this column data panel reflects.
+     * @param column   The column containing this panel
      * @param width    The width of the new column data panel in pixels.
      * @param variable The Data Column that this panel represents.
      * @param cellSelL Spreadsheet cell selection listener.
      */
-    public ColumnDataPanel(final DataStore db,
+    public ColumnDataPanel(final SpreadsheetColumn column,
                            final int width,
                            final Variable variable,
                            final CellSelectionListener cellSelL) {
@@ -105,7 +105,7 @@ public final class ColumnDataPanel extends JPanel implements KeyEventDispatcher 
         this.add(padding);
 
         // Populate the data column with spreadsheet cells.
-        buildDataPanelCells(db, variable, cellSelL);
+        buildDataPanelCells(column, variable, cellSelL);
     }
 
     /**
@@ -127,17 +127,17 @@ public final class ColumnDataPanel extends JPanel implements KeyEventDispatcher 
     /**
      * Build the SpreadsheetCells and add to the DataPanel.
      *
-     * @param db       The datastore holding cells that this column will represent.
+     * @param column   The column containing the cells
      * @param variable The variable to display.
      * @param cellSelL Spreadsheet listener to notify about cell selection
      *                 changes.
      */
-    private void buildDataPanelCells(final DataStore db, final Variable variable,
+    private void buildDataPanelCells(final SpreadsheetColumn column, final Variable variable,
                                      final CellSelectionListener cellSelL) {
 
         // traverse and build the cells
         for (Cell cell : variable.getCellsTemporally()) {
-            SpreadsheetCell sc = new SpreadsheetCell(db, cell, cellSelL);
+            SpreadsheetCell sc = new SpreadsheetCell(column, cell, cellSelL);
             cell.addListener(sc);
 
             // add cell to the JPanel
@@ -190,9 +190,9 @@ public final class ColumnDataPanel extends JPanel implements KeyEventDispatcher 
      * @param cellSelL SpreadsheetCellSelectionListener to notify of changes in
      *                 selection.
      */
-    public void insertCell(final DataStore ds, final Cell cell, final CellSelectionListener cellSelL) {
+    public void insertCell(final SpreadsheetColumn column, final Cell cell, final CellSelectionListener cellSelL) {
 
-        SpreadsheetCell nCell = new SpreadsheetCell(ds, cell, cellSelL);
+        SpreadsheetCell nCell = new SpreadsheetCell(column, cell, cellSelL);
         nCell.setWidth(this.getWidth());
         cell.addListener(nCell);
 //        cellSelectionL.clearColumnSelection();

--- a/src/main/java/org/datavyu/views/discrete/SpreadsheetCell.java
+++ b/src/main/java/org/datavyu/views/discrete/SpreadsheetCell.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import org.datavyu.Datavyu;
 import org.datavyu.models.db.Cell;
 import org.datavyu.models.db.CellListener;
-import org.datavyu.models.db.DataStore;
 import org.datavyu.models.db.CellValue;
 import org.datavyu.util.ClockTimer;
 import org.datavyu.util.ConfigProperties;
@@ -28,7 +27,6 @@ import org.datavyu.views.discrete.datavalues.TimeStampDataValueEditor.TimeStampS
 import org.datavyu.views.discrete.datavalues.TimeStampTextField;
 import org.jdesktop.application.Application;
 import org.jdesktop.application.ResourceMap;
-import org.jruby.RubyObject;
 
 import javax.swing.*;
 import javax.swing.Box.Filler;
@@ -156,12 +154,13 @@ public class SpreadsheetCell extends JPanel
     private boolean onsetProcessed = false;
     private boolean beingProcessed = false;
 
-    private SpreadsheetColumn parentColumn = null;
+    private final SpreadsheetColumn parentColumn;
 
-    public SpreadsheetCell(final DataStore cellDB,
+    public SpreadsheetCell(final SpreadsheetColumn parentColumn,
                            final Cell cell,
                            final CellSelectionListener listener) {
 
+        this.parentColumn = parentColumn;
         model = cell;
         setName(this.getClass().getSimpleName());
 
@@ -647,14 +646,6 @@ public class SpreadsheetCell extends JPanel
         Datavyu.getView().getSpreadsheetPanel().validate();
         Datavyu.getView().getSpreadsheetPanel().reorientView(this);
 
-        if(parentColumn == null) {
-            for (SpreadsheetColumn col : Datavyu.getView().getSpreadsheetPanel().getColumns()) {
-                if (col.getVariable() == model.getVariable()) {
-                    parentColumn = col;
-                    break;
-                }
-            }
-        }
         parentColumn.setSelected(true);
     }
 
@@ -662,15 +653,6 @@ public class SpreadsheetCell extends JPanel
     public void focusLost(final FocusEvent e) {
         if (brandNew) model.setSelected(false);
         brandNew = false;
-
-        if(parentColumn == null) {
-            for (SpreadsheetColumn col : Datavyu.getView().getSpreadsheetPanel().getColumns()) {
-                if (col.getVariable() == model.getVariable()) {
-                    parentColumn = col;
-                    break;
-                }
-            }
-        }
 
         parentColumn.setIndexOfPreviousFocusedCell(getDataView().getEdTracker().indexOfCurrentEditor());
 

--- a/src/main/java/org/datavyu/views/discrete/SpreadsheetColumn.java
+++ b/src/main/java/org/datavyu/views/discrete/SpreadsheetColumn.java
@@ -169,7 +169,7 @@ public final class SpreadsheetColumn extends JLabel implements VariableListener,
         if (var.getRootNode().type != Argument.Type.MATRIX) typeString = "  (" + var.getRootNode().type + ")";
         setText(var.getName() + typeString); //typeString for matrices is empty. Only displayed for non-matrix types (Text, Nominal)
 
-        datapanel = new ColumnDataPanel(db, width, var, cellSelL);
+        datapanel = new ColumnDataPanel(this, width, var, cellSelL);
         this.setVisible(!var.isHidden());
         datapanel.setVisible(!var.isHidden());
 
@@ -586,7 +586,7 @@ public final class SpreadsheetColumn extends JLabel implements VariableListener,
 
     @Override
     public void cellInserted(final Cell newCell) {
-        datapanel.insertCell(dataStore, newCell, cellSelList);
+        datapanel.insertCell(this, newCell, cellSelList);
     }
 
     @Override


### PR DESCRIPTION
This fixes a NullPointerException (#358) where parentColumn was null if none of
the cells in this column were focused/unfocused before the column's
variable was removed by a script call. Because the NPE was triggered
during evaluation of a script, the stack trace isn't shown to the user,
making it harder to track this down. I may try to address that in
another PR.