### PR TITLE
Fix cell font name and error message (#361)

### DIFF
--- a/src/main/java/org/datavyu/util/ConfigProperties.java
+++ b/src/main/java/org/datavyu/util/ConfigProperties.java
@@ -21,6 +21,7 @@ import org.jdesktop.application.LocalStorage;
 
 import java.awt.*;
 import java.io.*;
+import java.util.function.Consumer;
 
 /**
  * Configuration properties that are loaded from the settings.xml file in the resource folder.
@@ -254,15 +255,15 @@ public final class ConfigProperties implements Serializable {
             configurationProperties.setLastChosenDirectory(DEFAULT_LAST_CHOSEN_DIRECTORY);
         }
         try {
-            Font defaultFont = Font.createFont(Font.TRUETYPE_FONT,
-                    configurationProperties.getClass().getResourceAsStream(Constants.DEFAULT_FONT_FILE));
-            Font defaultCellFont = Font.createFont(Font.TRUETYPE_FONT,
-                    configurationProperties.getClass().getResourceAsStream(Constants.DEFAULT_CELL_FONT_FILE));
-            configurationProperties.setSpreadSheetDataFont(defaultCellFont.deriveFont(DEFAULT_DATA_FONT_SIZE));
-//            configurationProperties.setSpreadSheetDataFont(defaultFont.deriveFont(DEFAULT_DATA_FONT_SIZE));
-            configurationProperties.setSpreadSheetLabelFont(defaultFont.deriveFont(DEFAULT_LABEL_FONT_SIZE));
+            loadFont(Constants.DEFAULT_FONT_FILE, (font) -> {
+                configurationProperties.setSpreadSheetLabelFont(font.deriveFont(DEFAULT_LABEL_FONT_SIZE));
+                //configurationProperties.setSpreadSheetDataFont(font.deriveFont(DEFAULT_DATA_FONT_SIZE));
+            });
+            loadFont(Constants.DEFAULT_CELL_FONT_FILE, (font) -> {
+                configurationProperties.setSpreadSheetDataFont(font.deriveFont(DEFAULT_DATA_FONT_SIZE));
+            });
         } catch (Exception e) {
-            logger.error("Error, unable to load font " + Constants.DEFAULT_FONT_FILE + ". The error is " + e);
+            logger.error(e.toString());
         }
 
         // In all cases save this setting for the next run
@@ -283,6 +284,15 @@ public final class ConfigProperties implements Serializable {
      */
     public static ConfigProperties getInstance() {
         return configurationProperties;
+    }
+
+    private static void loadFont(String fontPath, Consumer<Font> consumer) throws Exception {
+        try {
+            consumer.accept(Font.createFont(Font.TRUETYPE_FONT,
+                    configurationProperties.getClass().getResourceAsStream(fontPath)));
+        } catch (Exception e) {
+            throw new Exception("Error, unable to load font " + fontPath, e);
+        }
     }
 
     /**

--- a/src/main/java/org/datavyu/util/Constants.java
+++ b/src/main/java/org/datavyu/util/Constants.java
@@ -44,7 +44,7 @@ public final class Constants {
     public static final String DEFAULT_FONT_FILE = "/fonts/DejaVuSansCondensed.ttf";
 
     /** Cell Unicode Font file name */
-    public static final String DEFAULT_CELL_FONT_FILE = "/fonts/unifont.ttf";
+    public static final String DEFAULT_CELL_FONT_FILE = "/fonts/unifont-10.0.07.ttf";
 
     /** Buffer size when copying files from streams */
     public static final int BUFFER_COPY_SIZE = 16*1024; // 16 kB


### PR DESCRIPTION
The error text was referring only to the default font path, obscuring
the actual error, which was that unifont.ttf is actually named
unifont-10.0.07. This change appears to have always been broken, and may
not be desirable on macOS anyway because it changes the cell data font
to a less clear monospace font.